### PR TITLE
Add -awakeFromNib override

### DIFF
--- a/MotionJpegImageView/MotionJpegImageView.mm
+++ b/MotionJpegImageView/MotionJpegImageView.mm
@@ -319,6 +319,17 @@ static NSData *_endMarkerData = nil;
     return self;
 }
 
+-(void)awakeFromNib {
+    [super awakeFromNib];
+    
+    if (_endMarkerData == nil) {
+        uint8_t endMarker[2] = END_MARKER_BYTES;
+        _endMarkerData = [[NSData alloc] initWithBytes:endMarker length:2];
+    }
+    
+    self.contentMode = UIViewContentModeScaleAspectFit;
+}
+
 #pragma mark - Overrides
 
 - (void)dealloc {


### PR DESCRIPTION
I added an override of the -awakeFromNib method, so that a MotionJpegImageView will work properly when loaded from a NIB instead of being initialized with -initWithFrame.

Without this override, if the view is loaded from a NIB, the view crashes when data is received, because _endMarkerData is not initialized.
